### PR TITLE
WIP: API update to allow fix_line_ratios in JSON input

### DIFF
--- a/nuskybgd/cli.py
+++ b/nuskybgd/cli.py
@@ -220,7 +220,9 @@ Sample bgdinfo.json:
             [3, 4],
             [5, 6]
         ]
-    }
+    },
+    
+    "fix_line_ratios": true
 }
 """
 
@@ -280,7 +282,8 @@ Sample bgdinfo.json:
     # arbitrary but the same ones must be used in subsequent processes that
     # will load this Xspec save file.
     numodel.applymodel_apbgd(presets, refspec, bgdapimwt, 2)
-    numodel.applymodel_intbgd(presets, refspec, bgddetimsum, 3)
+    numodel.applymodel_intbgd(presets, refspec, bgddetimsum,3, 
+        fix_line_ratios=bgdinfo['fix_line_ratios'])
     numodel.applymodel_fcxb(refspec, bgddetimsum, 4)
     numodel.applymodel_intn(presets, refspec, bgddetimsum, 5)
     if 'fcxb_config' in bgdinfo and 'links' in bgdinfo['fcxb_config']:
@@ -437,7 +440,8 @@ def spec(args=[]):
     ##########
     # These models need to have the same number as in fit() or it won't work!
     numodel.applymodel_apbgd(presets, refspec, bgdapimwt, 2, src_number=src_number)
-    numodel.applymodel_intbgd(presets, refspec, bgddetimsum, 3, src_number=src_number)
+    numodel.applymodel_intbgd(presets, refspec, bgddetimsum,3, 
+        fix_line_ratios=bgdinfo['fix_line_ratios'])
     numodel.applymodel_fcxb(refspec, bgddetimsum, 4, src_number=src_number)
     numodel.applymodel_intn(presets, refspec, bgddetimsum, 5, src_number=src_number)
     ##########

--- a/nuskybgd/cli.py
+++ b/nuskybgd/cli.py
@@ -441,7 +441,7 @@ def spec(args=[]):
     # These models need to have the same number as in fit() or it won't work!
     numodel.applymodel_apbgd(presets, refspec, bgdapimwt, 2, src_number=src_number)
     numodel.applymodel_intbgd(presets, refspec, bgddetimsum,3, 
-        fix_line_ratios=bgdinfo['fix_line_ratios'])
+        fix_line_ratios=bgdinfo['fix_line_ratios'], src_number=src_number)
     numodel.applymodel_fcxb(refspec, bgddetimsum, 4, src_number=src_number)
     numodel.applymodel_intn(presets, refspec, bgddetimsum, 5, src_number=src_number)
     ##########

--- a/nuskybgd/model.py
+++ b/nuskybgd/model.py
@@ -63,6 +63,9 @@ def check_bgdinfofile(bgdinfofile):
     queue.append(bgdinfo['bgdapfiles']['A'])
     queue.append(bgdinfo['bgdapfiles']['B'])
 
+    if 'fix_line_ratios' not in bgdinfo:
+        bgdinfo['fix_line_ratios'] = False
+
     for _ in queue:
         if not os.path.exists(_):
             problem = True

--- a/nuskybgd/model.py
+++ b/nuskybgd/model.py
@@ -612,9 +612,16 @@ def applymodel_intbgd(presets, refspec, bgddetimsum, model_num,
                 })
 
                 if fix_line_ratios:
-                    lorentz_5_norm_npar = spec_arrinx * m.nParameters + 16
+                    if attr_n == 5:
+                        # If you're lorentz_6 then you can pick up the line norm
+                        # from above. 
+                        base_norm = line_norm
+                        lorentz_5_norm_npar = spec_arrinx * m.nParameters + 16
 
-                    line_ratio = norm_preset / m.lorentz_5.norm.values[0]
+#                   This doesn't work because we haven't told the model what it's value
+#                   is yet.
+#                    line_ratio = norm_preset / m.lorentz_5.norm.values[0]
+                    line_ratio = norm_preset / base_norm
 
                     newpar.update({
                         parnum + 2: f"={line_ratio:e} * {model_name}:{lorentz_5_norm_npar}"


### PR DESCRIPTION
Added docstring info

Defaults to False

Have to be careful with true/false (JSON) and True/False (python) implementations.

Haven't handled a string "True" or anything else yet in the JSON. But in testing seems to work.

Will probably want to rebase after #6 

Had to track in both "fit" and "spec" in cli.py and haven't testing "spec" yet